### PR TITLE
Added config option to limit read lines to current visible window

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ You can pass your config table into the `setup()` function.
 - `disabled_filetypes`: the `colorcolumn` will be disabled under the filetypes in this table
   - type of the value: table of strings
   - default value: `{ "help", "text", "markdown" }`
+- `limit_to_window`: the `colorcolumn` will be displayed based on the visible lines in the window instead of all lines in the current buffer
+  - type of the value: boolean
+  - default value: `false`
+
   
 ### Default config
 
@@ -75,5 +79,6 @@ You can pass your config table into the `setup()` function.
 local config = {
    colorcolumn = 80,
    disabled_filetypes = { "help", "text", "markdown" },
+   limit_to_window = false,
 }
 ```

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -1,65 +1,60 @@
 local smartcolumn = {}
 
 local config = {
-    colorcolumn = 80,
-    disabled_filetypes = { "help", "text", "markdown" },
-    limit_to_window = false,
+   colorcolumn = 80,
+   disabled_filetypes = { "help", "text", "markdown" },
+   limit_to_window = false,
 }
 
 local function is_disabled()
 local current_filetype = vim.api.nvim_buf_get_option(0, "filetype")
 for _, filetype in pairs(config.disabled_filetypes) do
-    if filetype == current_filetype then
-        return true
-    end
+   if filetype == current_filetype then
+       return true
+   end
 end
 return false
 end
 
 local function detect()
-    local max_column = 0
-    local current_buf = vim.api.nvim_get_current_buf()
-    local lines
-    if config.limit_to_window then
-        lines = vim.api.nvim_buf_get_lines(current_buf, vim.fn.line("w0"), vim.fn.line("w$"), false)
-    else
-        lines = vim.api.nvim_buf_get_lines(current_buf, 0, -1, true)
-    end
-    for _, line in pairs(lines) do
-        max_column = math.max(max_column, vim.fn.strdisplaywidth(line))
-    end
+   local max_column = 0
+   local current_buf = vim.api.nvim_get_current_buf()
+   local lines
+   if config.limit_to_window then
+      lines = vim.api.nvim_buf_get_lines(current_buf, vim.fn.line("w0"), vim.fn.line("w$"), false)
+   else
+      lines = vim.api.nvim_buf_get_lines(current_buf, 0, -1, true)
+   end
+   for _, line in pairs(lines) do
+      max_column = math.max(max_column, vim.fn.strdisplaywidth(line))
+   end
 
-    local value = ""
-    if not is_disabled() and max_column >= config.colorcolumn then
-        value = tostring(config.colorcolumn)
-    end
-
-    local windows = vim.api.nvim_list_wins()
-    for _, window in pairs(windows) do
-        if vim.api.nvim_win_get_buf(window) == current_buf then
-            if not is_disabled() and max_column > config.colorcolumn then
-                vim.api.nvim_win_set_option(window, "colorcolumn", tostring(config.colorcolumn))
-            else
-                vim.api.nvim_win_set_option(window, "colorcolumn", "")
-            end
-        end
-    end
+   local windows = vim.api.nvim_list_wins()
+   for _, window in pairs(windows) do
+      if vim.api.nvim_win_get_buf(window) == current_buf then
+         if not is_disabled() and max_column > config.colorcolumn then
+            vim.api.nvim_win_set_option(window, "colorcolumn", tostring(config.colorcolumn))
+         else
+            vim.api.nvim_win_set_option(window, "colorcolumn", "")
+         end
+      end
+   end
 end
 
 function smartcolumn.setup(user_config)
-    user_config = user_config or {}
+   user_config = user_config or {}
 
-    for option, value in pairs(user_config) do
-        config[option] = value
-    end
+   for option, value in pairs(user_config) do
+      config[option] = value
+   end
 
-    local cmd_groups
-    if config['limit_to_window'] then
-        cmd_groups = { "BufEnter", "CursorMoved", "CursorMovedI" }
-    else
-        cmd_groups = { "BufEnter", "TextChanged", "TextChangedI" }
-    end
-    vim.api.nvim_create_autocmd(cmd_groups, { callback = detect })
+   local cmd_groups
+   if config['limit_to_window'] then
+      cmd_groups = { "BufEnter", "CursorMoved", "CursorMovedI" }
+   else
+      cmd_groups = { "BufEnter", "TextChanged", "TextChangedI" }
+   end
+   vim.api.nvim_create_autocmd(cmd_groups, { callback = detect })
 end
 
 return smartcolumn

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -18,22 +18,24 @@ end
 
 local function detect()
    local max_column = 0
-   local current_buf = vim.api.nvim_get_current_buf()
    local lines
    if config.limit_to_window then
-      lines = vim.api.nvim_buf_get_lines(current_buf, vim.fn.line("w0"), vim.fn.line("w$"), false)
+      lines = vim.api.nvim_buf_get_lines(0, vim.fn.line("w0"),
+         vim.fn.line("w$"), true)
    else
-      lines = vim.api.nvim_buf_get_lines(current_buf, 0, -1, true)
+      lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
    end
    for _, line in pairs(lines) do
       max_column = math.max(max_column, vim.fn.strdisplaywidth(line))
    end
 
+   local current_buf = vim.api.nvim_get_current_buf()
    local windows = vim.api.nvim_list_wins()
    for _, window in pairs(windows) do
       if vim.api.nvim_win_get_buf(window) == current_buf then
          if not is_disabled() and max_column > config.colorcolumn then
-            vim.api.nvim_win_set_option(window, "colorcolumn", tostring(config.colorcolumn))
+            vim.api.nvim_win_set_option(window, "colorcolumn",
+               tostring(config.colorcolumn))
          else
             vim.api.nvim_win_set_option(window, "colorcolumn", "")
          end
@@ -48,13 +50,8 @@ function smartcolumn.setup(user_config)
       config[option] = value
    end
 
-   local cmd_groups
-   if config['limit_to_window'] then
-      cmd_groups = { "BufEnter", "CursorMoved", "CursorMovedI" }
-   else
-      cmd_groups = { "BufEnter", "TextChanged", "TextChangedI" }
-   end
-   vim.api.nvim_create_autocmd(cmd_groups, { callback = detect })
+   vim.api.nvim_create_autocmd({ "BufEnter", "CursorMoved", "CursorMovedI" },
+      { callback = detect })
 end
 
 return smartcolumn

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -10,7 +10,7 @@ local function is_disabled()
    local current_filetype = vim.api.nvim_buf_get_option(0, "filetype")
    for _, filetype in pairs(config.disabled_filetypes) do
       if filetype == current_filetype then
-          return true
+         return true
       end
    end
    return false

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -7,13 +7,13 @@ local config = {
 }
 
 local function is_disabled()
-local current_filetype = vim.api.nvim_buf_get_option(0, "filetype")
-for _, filetype in pairs(config.disabled_filetypes) do
-   if filetype == current_filetype then
-       return true
+   local current_filetype = vim.api.nvim_buf_get_option(0, "filetype")
+   for _, filetype in pairs(config.disabled_filetypes) do
+      if filetype == current_filetype then
+          return true
+      end
    end
-end
-return false
+   return false
 end
 
 local function detect()

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -1,50 +1,65 @@
 local smartcolumn = {}
 
 local config = {
-   colorcolumn = 80,
-   disabled_filetypes = { "help", "text", "markdown" },
+    colorcolumn = 80,
+    disabled_filetypes = { "help", "text", "markdown" },
+    limit_to_window = false,
 }
 
 local function is_disabled()
-   local current_filetype = vim.api.nvim_buf_get_option(0, "filetype")
-   for _, filetype in pairs(config.disabled_filetypes) do
-      if filetype == current_filetype then
-         return true
-      end
-   end
-   return false
+local current_filetype = vim.api.nvim_buf_get_option(0, "filetype")
+for _, filetype in pairs(config.disabled_filetypes) do
+    if filetype == current_filetype then
+        return true
+    end
+end
+return false
 end
 
 local function detect()
-   local max_column = 0
-   local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
-   for _, line in pairs(lines) do
-      max_column = math.max(max_column, vim.fn.strdisplaywidth(line))
-   end
+    local max_column = 0
+    local current_buf = vim.api.nvim_get_current_buf()
+    local lines
+    if config.limit_to_window then
+        lines = vim.api.nvim_buf_get_lines(current_buf, vim.fn.line("w0"), vim.fn.line("w$"), false)
+    else
+        lines = vim.api.nvim_buf_get_lines(current_buf, 0, -1, true)
+    end
+    for _, line in pairs(lines) do
+        max_column = math.max(max_column, vim.fn.strdisplaywidth(line))
+    end
 
-   local value = ""
-   if not is_disabled() and max_column >= config.colorcolumn then
-      value = tostring(config.colorcolumn)
-   end
+    local value = ""
+    if not is_disabled() and max_column >= config.colorcolumn then
+        value = tostring(config.colorcolumn)
+    end
 
-   local current_buf = vim.api.nvim_get_current_buf()
-   local windows = vim.api.nvim_list_wins()
-   for _, window in pairs(windows) do
-      if vim.api.nvim_win_get_buf(window) == current_buf then
-         vim.api.nvim_win_set_option(window, "colorcolumn", value)
-      end
-   end
+    local windows = vim.api.nvim_list_wins()
+    for _, window in pairs(windows) do
+        if vim.api.nvim_win_get_buf(window) == current_buf then
+            if not is_disabled() and max_column > config.colorcolumn then
+                vim.api.nvim_win_set_option(window, "colorcolumn", tostring(config.colorcolumn))
+            else
+                vim.api.nvim_win_set_option(window, "colorcolumn", "")
+            end
+        end
+    end
 end
 
 function smartcolumn.setup(user_config)
-   user_config = user_config or {}
+    user_config = user_config or {}
 
-   for option, value in pairs(user_config) do
-      config[option] = value
-   end
+    for option, value in pairs(user_config) do
+        config[option] = value
+    end
 
-   vim.api.nvim_create_autocmd({ "BufEnter", "TextChanged", "TextChangedI" },
-      { callback = detect })
+    local cmd_groups
+    if config['limit_to_window'] then
+        cmd_groups = { "BufEnter", "CursorMoved", "CursorMovedI" }
+    else
+        cmd_groups = { "BufEnter", "TextChanged", "TextChangedI" }
+    end
+    vim.api.nvim_create_autocmd(cmd_groups, { callback = detect })
 end
 
 return smartcolumn


### PR DESCRIPTION
Added a config option named `limit_to_window` which will only show the colorcolumn if a line visible in the current window is over the specified column number.

Will continue to function as it does now if `limit_to_window` is set to the default value of `false`.