### PR TITLE
filetype-specific colorcolumn values

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A Neovim plugin hiding your colorcolumn when unneeded.
 
 - The colorcolumn is hidden as default, but it appears after one of lines in the file exceeds the `colorcolumn` value you set.
 - The colorcolumn is hidden in the filetypes in `disabled_filetypes`.
+- You can set custom colorcolumn value for different filetype.
 
 ## 📦 Installation
 
@@ -65,6 +66,8 @@ require("smartcolumn").setup()
 
 You can pass your config table into the `setup()` function.
 
+The available options:
+
 - `colorcolumn`: screen columns that are highlighted
   - type of the value: integer
   - default value: `80`
@@ -74,9 +77,11 @@ You can pass your config table into the `setup()` function.
 - `limit_to_window`: the `colorcolumn` will be displayed based on the visible lines in the window instead of all lines in the current buffer
   - type of the value: boolean
   - default value: `false`
-- `filetype_colorcolumns`: filetype-specific values for `colorcolumn`. when editing a buffer with a filetype present in this table, the value for that filetype will be used in place of `config.colorcolumn`. for example, with `filetype_colorcolumns = { ruby = 120, java = 200 }` the colorcolumn will appear at 120 characters when editing a buffer with filetype `ruby`, but will appear at 200 characters when editing a buffer with filetype `java`.
+- `custom_colorcolumn`: custom `colorcolumn` values for different filetype. when editing a buffer with a filetype present in this table, the value for that filetype will be used in place of `config.colorcolumn`.
   - type of the value: table of filetype names to integers
   - default value: `{}`
+
+Example: With `custom_colorcolumn = { ruby = 120, java = 200 }` the colorcolumn will appear at 120 characters when editing a buffer with filetype `ruby`, but will appear at 200 characters when editing a buffer with filetype `java`.
 
   
 ### Default config
@@ -85,7 +90,7 @@ You can pass your config table into the `setup()` function.
 local config = {
    colorcolumn = 80,
    disabled_filetypes = { "help", "text", "markdown" },
-   filetype_colorcolumns = {},
+   custom_colorcolumn = {},
    limit_to_window = false,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ You can pass your config table into the `setup()` function.
 - `limit_to_window`: the `colorcolumn` will be displayed based on the visible lines in the window instead of all lines in the current buffer
   - type of the value: boolean
   - default value: `false`
+- `filetype_colorcolumns`: filetype-specific values for `colorcolumn`. when editing a buffer with a filetype present in this table, the value for that filetype will be used in place of `config.colorcolumn`. for example, with `filetype_colorcolumns = { ruby = 120, java = 200 }` the colorcolumn will appear at 120 characters when editing a buffer with filetype `ruby`, but will appear at 200 characters when editing a buffer with filetype `java`.
+  - type of the value: table of filetype names to integers
+  - default value: `{}`
 
   
 ### Default config
@@ -82,6 +85,7 @@ You can pass your config table into the `setup()` function.
 local config = {
    colorcolumn = 80,
    disabled_filetypes = { "help", "text", "markdown" },
+   filetype_colorcolumns = {},
    limit_to_window = false,
 }
 ```

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -3,7 +3,7 @@ local smartcolumn = {}
 local config = {
    colorcolumn = 80,
    disabled_filetypes = { "help", "text", "markdown" },
-   filetype_colorcolumns = {},
+   custom_colorcolumn = {},
    limit_to_window = false,
 }
 
@@ -18,7 +18,6 @@ local function is_disabled()
 end
 
 local function detect()
-   local max_column = 0
    local lines
    if config.limit_to_window then
       lines = vim.api.nvim_buf_get_lines(0, vim.fn.line("w0"),
@@ -26,14 +25,18 @@ local function detect()
    else
       lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
    end
+
+   local max_column = 0
    for _, line in pairs(lines) do
       max_column = math.max(max_column, vim.fn.strdisplaywidth(line))
    end
 
+   local buf_filetype = vim.api.nvim_buf_get_option(0, "filetype")
+   local colorcolumn =
+      config.custom_colorcolumn[buf_filetype] or config.colorcolumn
+
    local current_buf = vim.api.nvim_get_current_buf()
    local windows = vim.api.nvim_list_wins()
-   local buf_filetype = vim.api.nvim_buf_get_option(current_buf, "filetype")
-   local colorcolumn = config.filetype_colorcolumns[buf_filetype] or config.colorcolumn
    for _, window in pairs(windows) do
       if vim.api.nvim_win_get_buf(window) == current_buf then
          if not is_disabled() and max_column > colorcolumn then

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -3,6 +3,7 @@ local smartcolumn = {}
 local config = {
    colorcolumn = 80,
    disabled_filetypes = { "help", "text", "markdown" },
+   filetype_colorcolumns = {},
    limit_to_window = false,
 }
 
@@ -31,11 +32,13 @@ local function detect()
 
    local current_buf = vim.api.nvim_get_current_buf()
    local windows = vim.api.nvim_list_wins()
+   local buf_filetype = vim.api.nvim_buf_get_option(current_buf, "filetype")
+   local colorcolumn = config.filetype_colorcolumns[buf_filetype] or config.colorcolumn
    for _, window in pairs(windows) do
       if vim.api.nvim_win_get_buf(window) == current_buf then
-         if not is_disabled() and max_column > config.colorcolumn then
+         if not is_disabled() and max_column > colorcolumn then
             vim.api.nvim_win_set_option(window, "colorcolumn",
-               tostring(config.colorcolumn))
+               tostring(colorcolumn))
          else
             vim.api.nvim_win_set_option(window, "colorcolumn", "")
          end


### PR DESCRIPTION
howdy! I really like this plugin - the only thing I needed was the ability to set a `colorcolumn` value for specific filetypes (my work project enforces a line length of 120 for ruby files specifically).

I added `filetype_colorcolumns` to the config which accepts a table of filetype names and colorcolumn values, eg:

```lua
require('smartcolumn').setup({
  colorcolumn = 80,
  filetype_colorcolumns = {
    ruby = 120,
  }
})
```

I'm not in love with `filetype_colorcolumns` as a config name, open to suggestions there.