### PR TITLE
Update colorcolumn value only when state changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The available options:
   - `{ "80", "100" }`
 - `disabled_filetypes` (table of strings) : the `colorcolumn` will be disabled under the filetypes in this table
   - `{ "help", "text", "markdown" }` (default)
-  - `{ "NvimTree", "Lazy", "mason", "help" }`
+  - `{ "NvimTree", "lazy", "mason", "help" }`
 - `scope` (strings): the plugin only checks whether the lines within scope exceed colorcolumn
   - `"file"` (default): current file
   - `"window"`: visible part of current window

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -35,6 +35,7 @@ local function exceed(buf, win, min_colorcolumn)
    return not is_disabled() and max_column > min_colorcolumn
 end
 
+local buf_states = {}
 local function update()
    local buf_filetype = vim.api.nvim_buf_get_option(0, "filetype")
    local colorcolumns =
@@ -54,14 +55,18 @@ local function update()
    for _, win in pairs(wins) do
       local buf = vim.api.nvim_win_get_buf(win)
       if buf == current_buf then
-         if exceed(buf, win, min_colorcolumn) then
-            if type(colorcolumns) == "table" then
-               vim.wo[win].colorcolumn = table.concat(colorcolumns, ",")
+         local current_state = exceed(buf, win, min_colorcolumn)
+         if current_state ~= buf_states[buf] then
+            buf_states[buf] = current_state
+            if current_state then
+               if type(colorcolumns) == "table" then
+                  vim.wo[win].colorcolumn = table.concat(colorcolumns, ",")
+               else
+                  vim.wo[win].colorcolumn = colorcolumns
+               end
             else
-               vim.wo[win].colorcolumn = colorcolumns
+               vim.wo[win].colorcolumn = nil
             end
-         else
-            vim.wo[win].colorcolumn = nil
          end
       end
    end

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -35,7 +35,6 @@ local function exceed(buf, win, min_colorcolumn)
    return not is_disabled() and max_column > min_colorcolumn
 end
 
-local buf_states = {}
 local function update()
    local buf_filetype = vim.api.nvim_buf_get_option(0, "filetype")
    local colorcolumns =
@@ -56,8 +55,8 @@ local function update()
       local buf = vim.api.nvim_win_get_buf(win)
       if buf == current_buf then
          local current_state = exceed(buf, win, min_colorcolumn)
-         if current_state ~= buf_states[buf] then
-            buf_states[buf] = current_state
+         if current_state ~= vim.b.prev_state then
+            vim.b.prev_state = current_state
             if current_state then
                if type(colorcolumns) == "table" then
                   vim.wo[win].colorcolumn = table.concat(colorcolumns, ",")


### PR DESCRIPTION
### Main Problem
When calling `vim.wo[win].colorcolumn` the cursor (column) position behaves in a weird way. Example: #10 

### Workaround
Through the introduction of a table which always contains the last change in return value of the `exceed()` function for given buffer the `vim.wo[win].colorcolumn` value will not be set on every cursor move but only when the return value of the `exceed()` function changes. Therefore the cursor behavior will be closer to the expected behavior.

**Important note:** when `scope = "line"` is set the bug will still persist.