### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The available options:
   - `{ "80", "100" }`
 - `disabled_filetypes` (table of strings) : the `colorcolumn` will be disabled under the filetypes in this table
   - `{ "help", "text", "markdown" }` (default)
-  - `{ "NvimTree", "Lazy", "mason", "help" }`
+  - `{ "NvimTree", "lazy", "mason", "help" }`
 - `scope` (strings): the plugin only checks whether the lines within scope exceed colorcolumn
   - `"file"` (default): current file
   - `"window"`: visible part of current window


### PR DESCRIPTION
### Problem
There is an error/typo in the read-me where it states the file type of `lazy.nvim` is `Lazy` but it is `lazy`.

### Solution
The file type was queried by using the `:set filetype?` command in nvim.