### PR TITLE
fix(wrap): resolve #17

### DIFF
--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -70,7 +70,7 @@ local function exceed(buf, win, min_colorcolumn)
 
       max_column = math.max(max_column, column_number)
       if vim.wo[win].wrap == true then
-         local wrapped_rows = math.ceil(column_number / win_width)
+         local wrapped_rows = math.ceil(column_number / (win_width - gutter_width))
          if not num_rows_changed then
              num_rows_changed = (vim.b.prev_num_wrapped_rows ~= wrapped_rows)
              vim.b.prev_num_wrapped_rows = wrapped_rows

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -8,7 +8,7 @@ local config = {
 }
 
 -- merge values from t2 into t1. returns t1
-local function table_merge(t1, t2) 
+local function table_merge(t1, t2)
     for _, v in ipairs(t2) do
         table.insert(t1, v)
     end
@@ -25,7 +25,7 @@ local function get_wrapped_column_numbers(unwrapped_col_width,
    min_colorcolumn
    )
    local t = {}
-   if column_len <= min_colorcolumn then
+   if column_len <= min_colorcolumn or wrapped_col_width - gutter_width <= min_colorcolumn then
        return t
    end
    local c_col = min_colorcolumn
@@ -77,7 +77,7 @@ local function exceed(buf, win, min_colorcolumn)
              vim.b.prev_num_wrapped_rows = wrapped_rows
              vim.b.prev_screen_width = win_width
          end
-         local unwrapped_col_width = wrapped_rows * column_number
+         local unwrapped_col_width = wrapped_rows * (win_width - gutter_width)
          exceed_columns = get_wrapped_column_numbers(unwrapped_col_width,
             win_width, gutter_width, column_number, min_colorcolumn)
          exceed_table = table_merge(exceed_table, exceed_columns)

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -7,6 +7,14 @@ local config = {
    scope = "file",
 }
 
+-- merge values from t2 into t1. returns t1
+local function table_merge(t1, t2) 
+    for _, v in ipairs(t2) do
+        table.insert(t1, v)
+    end
+    return t1
+end
+
 -- this function returns the multiples of `column_len` that are less than
 -- `unwrapped_col_width` mod the `wrapped_col_width`, minus the gutter width
 -- returns a table containing the multiples of `column_len`
@@ -70,7 +78,7 @@ local function exceed(buf, win, min_colorcolumn)
          local unwrapped_col_width = wrapped_rows * column_number
          exceed_columns = get_wrapped_column_numbers(unwrapped_col_width,
             win_width, gutter_width, column_number, min_colorcolumn)
-         exceed_table = vim.tbl_extend("keep", exceed_table, exceed_columns)
+         exceed_table = table_merge(exceed_table, exceed_columns)
       else
           num_rows_changed = (vim.b.prev_num_wrapped_rows ~= 1)
           vim.b.prev_num_wrapped_rows = 1
@@ -99,11 +107,11 @@ local function set_win_colorcolumns(buf, win, colorcolumns)
    if type(colorcolumns) == "table" then
       local colorcolumns_to_set = {}
       local diff_state = nil
-      for _, colorcolumn in colorcolumns do
+      for _, colorcolumn in ipairs(colorcolumns) do
          current_state, exceed_cols = exceed(buf, win, tonumber(colorcolumn))
          if current_state ~= vim.b.prev_state then
-            vim.b.prev_state = current_state
-            colorcolumns_to_set = vim.tbl_extend("keep", colorcolumns_to_set, exceed_cols)
+            diff_state = current_state
+            colorcolumns_to_set = table_merge(colorcolumns_to_set, exceed_cols)
          end
       end
       if diff_state ~= nil then


### PR DESCRIPTION
This PR resolves #17: adding highlight capabilities to wrapped lines. Note that this is a significant overhaul of the `exceed` function.

Additionally, it adds a helper function `get_wrapped_column_numbers`, which is just a wrapper around some window math.

Instead of returning a boolean, `exceed` now returns a `state` (type `int`) and a table (`int[]`) of exceeding columns, wrapped to next lines when `wrap` is true. 