### PR TITLE
More about how to get one's filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ A Neovim plugin hiding your colorcolumn when unneeded.
 
 ## ⚙️ Features
 
-The colorcolumn is hidden as default, but it appears after one of lines in the scope exceeds the `colorcolumn` value you set.
+The colorcolumn is hidden as default, but it appears after one of lines in the
+scope exceeds the `colorcolumn` value you set.
 
 You can:
+
 - hide colorcolumn for specific filetype
 - set custom colorcolumn value for different filetype
 - specify the scope where the plugin should work
@@ -43,6 +45,7 @@ You can:
 1. Install via your favorite package manager.
 
 - [lazy.nvim](https://github.com/folke/lazy.nvim)
+
 ```Lua
 {
   "m4xshen/smartcolumn.nvim",
@@ -51,37 +54,45 @@ You can:
 ```
 
 - [packer.nvim](https://github.com/wbthomason/packer.nvim)
+
 ```Lua
 use "m4xshen/smartcolumn.nvim"
 ```
 
 - [vim-plug](https://github.com/junegunn/vim-plug)
+
 ```VimL
 Plug "m4xshen/smartcolumn.nvim"
 ```
 
-2. Setup the plugin in your `init.lua`. This step is not needed with lazy.nvim if `opts` is set as above.
+2. Setup the plugin in your `init.lua`. This step is not needed with lazy.nvim
+   if `opts` is set as above.
+
 ```Lua
 require("smartcolumn").setup()
 ```
 
 ## 🔧 Configuration
 
-You can pass your config table into the `setup()` function or `opts` if you use lazy.nvim.
+You can pass your config table into the `setup()` function or `opts` if you use
+lazy.nvim.
 
 The available options:
 
 - `colorcolumn` (strings or table) : screen columns that are highlighted
   - `"80"` (default)
   - `{ "80", "100" }`
-- `disabled_filetypes` (table of strings) : the `colorcolumn` will be disabled under the filetypes in this table
+- `disabled_filetypes` (table of strings) : the `colorcolumn` will be disabled
+  under the filetypes in this table
   - `{ "help", "text", "markdown" }` (default)
-  - `{ "NvimTree", "lazy", "mason", "help" }`
-- `scope` (strings): the plugin only checks whether the lines within scope exceed colorcolumn
+  - `{ "NvimTree", "lazy", "mason", "help", "checkhealth", "lspinfo", "noice", "Trouble","fish", "zsh"}`
+- `scope` (strings): the plugin only checks whether the lines within scope
+  exceed colorcolumn
   - `"file"` (default): current file
   - `"window"`: visible part of current window
   - `"line"`: current line
-- `custom_colorcolumn` (table or function returning string): custom `colorcolumn` values for different filetypes
+- `custom_colorcolumn` (table or function returning string): custom
+  `colorcolumn` values for different filetypes
   - `{}` (default)
   - `{ ruby = "120", java = { "180", "200"} }`
   - you can also pass a function to handle more complicated logic:

--- a/README.md
+++ b/README.md
@@ -87,12 +87,7 @@ The available options:
   - `{ "help", "text", "markdown" }` (default)
   - `{ "NvimTree", "lazy", "mason", "help", "checkhealth", "lspinfo", "noice", "Trouble", "fish", "zsh"}`
   > [!NOTE]
-  > Filetype Sometimes it is very hard to get one buffer's filetype,
-  > because some are very confusing (e.g., lspinfo). You can use
-  > `:set filetype?` to check the filetype of current buffer. If Vim or Neovim
-  > displays filetype= without any value, it means that the file type has not
-  > been set for the current buffer. In such cases, you may manually set the
-  > file type with :set filetype=type, where type is the desired file type.
+  > You can use `:set filetype?` to check the filetype of current buffer.
 - `scope` (strings): the plugin only checks whether the lines within scope
   exceed colorcolumn
   - `"file"` (default): current file

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ The available options:
   under the filetypes in this table
   - `{ "help", "text", "markdown" }` (default)
   - `{ "NvimTree", "lazy", "mason", "help", "checkhealth", "lspinfo", "noice", "Trouble", "fish", "zsh"}`
+  > [!NOTE]
+  > Filetype Sometimes it is very hard to get one buffer's filetype,
+  > because some are very confusing (e.g., lspinfo). You can use
+  > `:set filetype?` to check the filetype of current buffer. If Vim or Neovim
+  > displays filetype= without any value, it means that the file type has not
+  > been set for the current buffer. In such cases, you may manually set the
+  > file type with :set filetype=type, where type is the desired file type.
 - `scope` (strings): the plugin only checks whether the lines within scope
   exceed colorcolumn
   - `"file"` (default): current file

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The available options:
 - `disabled_filetypes` (table of strings) : the `colorcolumn` will be disabled
   under the filetypes in this table
   - `{ "help", "text", "markdown" }` (default)
-  - `{ "NvimTree", "lazy", "mason", "help", "checkhealth", "lspinfo", "noice", "Trouble","fish", "zsh"}`
+  - `{ "NvimTree", "lazy", "mason", "help", "checkhealth", "lspinfo", "noice", "Trouble", "fish", "zsh"}`
 - `scope` (strings): the plugin only checks whether the lines within scope
   exceed colorcolumn
   - `"file"` (default): current file


### PR DESCRIPTION
I think it is better to let the user choose which file type should be put in the `disabled_filetypes`, but from my experience, for some buffer it is difficult to know what kind of type it has, so I put extra explanation. 

I want to make an [alert block](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts), but I think my formatter ruins it every time I save it. Can you just let the text in the next line instead of staying besides `![NOTE]`?