### PR TITLE
feat: add EditorConfig option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,6 @@ local config = {
    disabled_filetypes = { "help", "text", "markdown" },
    custom_colorcolumn = {},
    scope = "file",
-   editorconfig = false,
+   editorconfig = true,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The available options:
      return "100"
   end
   ```
+- `editorconfig`: use `max_line_length` from EditorConfig, overrides `custom_colorcolumn`
 
 ### Default config
 
@@ -112,5 +113,6 @@ local config = {
    disabled_filetypes = { "help", "text", "markdown" },
    custom_colorcolumn = {},
    scope = "file",
+   editorconfig = false,
 }
 ```

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -5,6 +5,7 @@ local config = {
    disabled_filetypes = { "help", "text", "markdown" },
    custom_colorcolumn = {},
    scope = "file",
+   editorconfig = false,
 }
 
 local function exceed(buf, win, min_colorcolumn)
@@ -41,6 +42,13 @@ local function exceed(buf, win, min_colorcolumn)
       and max_column > min_colorcolumn
 end
 
+local function colorcolumn_editorconfig(colorcolumns)
+   return vim.b[0].editorconfig
+         and vim.b[0].editorconfig.max_line_length ~= "off"
+         and vim.b[0].editorconfig.max_line_length
+      or colorcolumns
+end
+
 local function update()
    local buf_filetype = vim.api.nvim_buf_get_option(0, "filetype")
    local colorcolumns
@@ -50,6 +58,10 @@ local function update()
    else
       colorcolumns = config.custom_colorcolumn[buf_filetype]
          or config.colorcolumn
+   end
+
+   if config.editorconfig then
+      colorcolumns = colorcolumn_editorconfig(colorcolumns)
    end
 
    local min_colorcolumn = colorcolumns

--- a/lua/smartcolumn.lua
+++ b/lua/smartcolumn.lua
@@ -5,7 +5,7 @@ local config = {
    disabled_filetypes = { "help", "text", "markdown" },
    custom_colorcolumn = {},
    scope = "file",
-   editorconfig = false,
+   editorconfig = true,
 }
 
 local function exceed(buf, win, min_colorcolumn)


### PR DESCRIPTION
Add an `editorconfig` option that uses `max_line_length` from EditorConfig as cursor column. If `vim.b[bufnr].editorconfig.max_line_length` is not set, it uses `config.colorcolumn` instead. 

Implemented as an overwrite of `custom_colorcolumn` to minimize changes to the existing code, though this implementation could be adjusted if needed.